### PR TITLE
set TTL

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -33,6 +33,7 @@ type (
 		Help       bool   `short:"h" long:"help" description:"Show this help message"`
 		KubeConfig string `long:"kubeconfig" description:"absolute path to K8s credential"`
 		TimeoutSec int    `short:"t" long:"timeoutsec" description:"timeout second"`
+		TTLSec     int32  `long:"ttlsec" description:"TTLSecondsAfterFinished of Job. This is alpha feature since v1.12" default:"300"`
 		Args       struct {
 			Path string
 		} `positional-args:"yes"`
@@ -111,7 +112,7 @@ func (c *cli) Run() int {
 		return 1
 	}
 
-	k, err := kubernetes.New(c.OutStream, c.Config.Namespace, c.Config.KubeConfig)
+	k, err := kubernetes.New(c.OutStream, c.Config.Namespace, c.Config.KubeConfig, c.Config.TTLSec)
 	if err != nil {
 		fmt.Fprintln(c.ErrStream, err)
 		return 1

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -79,6 +79,9 @@ func (c *jobCli) Create(ctx context.Context, image string) error {
 		errors.Wrapf(err, "failed to create batch, namespace: %s, image: %s", c.Namespace, image)
 	}
 	c.log.Printf("job created,  name: %s", createdJob.Name)
+	if createdJob.Spec.TTLSecondsAfterFinished == nil {
+		c.log.Println("TTLSecondsAfterFinished is not enabled on your cluster")
+	}
 
 	w, err := c.Clientset.BatchV1().Jobs(c.Namespace).Watch(metav1.ListOptions{})
 	defer w.Stop()


### PR DESCRIPTION
* for auto cleanup
* this is alpha feature since 1.12 so default is false and may be deleted in later version
https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#ttl-mechanism-for-finished-jobs

close #8 