### PR TITLE
fix: handle Create/Watch errors and scope timeout to job execution

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -69,19 +69,11 @@ func (c *cli) initConfig() error {
 }
 
 func (c *cli) Run() int {
-	ctx := context.Background()
-
 	err := c.initConfig()
 	if err != nil {
 		fmt.Fprintln(c.ErrStream, err)
 		return 1
 	}
-	timeout := defaultTimeoutSecond
-	if c.Config.TimeoutSec != 0 {
-		timeout = time.Duration(c.Config.TimeoutSec) * time.Second
-	}
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	builder, err := build.NewBuilder(c.OutStream)
 	if err != nil {
@@ -117,6 +109,15 @@ func (c *cli) Run() int {
 		fmt.Fprintln(c.ErrStream, err)
 		return 1
 	}
+
+	// The timeout bounds job execution only. Build and publish time varies
+	// with network conditions and must not eat into the job's budget.
+	timeout := defaultTimeoutSecond
+	if c.Config.TimeoutSec != 0 {
+		timeout = time.Duration(c.Config.TimeoutSec) * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 
 	err = k.Create(ctx, ref.Name())
 	if err != nil {

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -76,7 +76,7 @@ func (c *jobCli) Create(ctx context.Context, image string) error {
 	job := buildJob(image, c.Namespace, c.TTLSeconds)
 	createdJob, err := c.Clientset.BatchV1().Jobs(c.Namespace).Create(ctx, job, metav1.CreateOptions{})
 	if err != nil {
-		errors.Wrapf(err, "failed to create batch, namespace: %s, image: %s", c.Namespace, image)
+		return errors.Wrapf(err, "failed to create batch, namespace: %s, image: %s", c.Namespace, image)
 	}
 	c.log.Printf("job created,  name: %s", createdJob.Name)
 	if createdJob.Spec.TTLSecondsAfterFinished == nil {
@@ -84,6 +84,9 @@ func (c *jobCli) Create(ctx context.Context, image string) error {
 	}
 
 	w, err := c.Clientset.BatchV1().Jobs(c.Namespace).Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to watch jobs, namespace: %s", c.Namespace)
+	}
 	defer w.Stop()
 	ch := w.ResultChan()
 	for {
@@ -91,10 +94,14 @@ func (c *jobCli) Create(ctx context.Context, image string) error {
 		case <-ctx.Done():
 			c.log.Printf("job execution timeout name: %s\n", createdJob.Name)
 			return errors.Wrap(ctx.Err(), "job execution timeout")
-		case obj := <-ch:
+		case obj, ok := <-ch:
+			if !ok {
+				return errors.Errorf("watch channel closed before job finished, name: %s", createdJob.Name)
+			}
 			job, ok := obj.Object.(*batchv1.Job)
 			if !ok {
 				c.log.Printf("unexpected kind object: %v", obj)
+				continue
 			}
 			if createdJob.Name == job.Name && isFinished(job) {
 				c.log.Printf("job finished, name: %s\n", createdJob.Name)


### PR DESCRIPTION
## Summary

The CI e2e suite was flaky: the same commit passed and failed intermittently, occasionally with a SIGSEGV at `kubernetes.go:87`. Root cause is a chain of unhandled errors triggered by variable image publish time.

The `-t` timeout context started before build/publish. When a slow publish exhausted the budget, Job `Create` failed with `context deadline exceeded`, but:

1. the error was wrapped with `errors.Wrapf` and **never returned**, so execution continued (client-go returns a non-nil empty Job on error, so the following log printed `job created,  name: ` with an empty name)
2. `Watch` then failed on the expired context, its error was never checked, and `defer w.Stop()` dereferenced the nil watch → SIGSEGV

## Changes

- `pkg/kubernetes/kubernetes.go`
  - return the wrapped error when Job `Create` fails
  - check the `Watch` error before `defer w.Stop()`
  - detect `ResultChan` closure and return instead of spinning on zero values
  - `continue` on non-Job watch events instead of dereferencing the failed type assertion
- `pkg/cli/cli.go`
  - start the `-t` timeout context just before job creation, so build/publish time no longer eats into the job execution budget (matches the "job execution timeout" semantics and makes the `with timeout option` e2e case deterministic)

## Verification

- Reproduced the SIGSEGV deterministically on `master` with `-t 1` against a local kind cluster; the fixed binary under the same conditions creates the job and exits cleanly with `job execution timeout` (exit 1)
- `make test_e2e` passed 4 consecutive runs (`-count=1`) against a local kind cluster + local registry
- CI (kind + Docker Hub) passed on this branch

Out of scope (tracked separately): `getKubeConfig` has an inverted error check (`err != nil` should be `err == nil`) that breaks the `~/.kube/config` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)