### PR TITLE
fix: fall back to ~/.kube/config when UserHomeDir succeeds

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -66,7 +66,7 @@ func getKubeConfig(kc string) (string, error) {
 	if os.Getenv("KUBECONFIG") != "" {
 		return os.Getenv("KUBECONFIG"), nil
 	}
-	if home, err := os.UserHomeDir(); home != "" && err != nil {
+	if home, err := os.UserHomeDir(); home != "" && err == nil {
 		return filepath.Join(home, ".kube", "config"), nil
 	}
 	return "", errors.New("kubectx not found")


### PR DESCRIPTION
## Summary
- `getKubeConfig` の home ディレクトリフォールバック条件が `err != nil`(誤)になっており、`os.UserHomeDir()` が成功すると条件が false になるバグを修正
- この影響で、`--kubeconfig` フラグも `KUBECONFIG` 環境変数も未指定の場合に `~/.kube/config` へフォールバックできず "kubectx not found" エラーになっていた
- 条件を `home != "" && err == nil` に修正

## Verification
- `go build ./... && go vet ./...` が exit 0 で通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)